### PR TITLE
[[FIX]] Instantiation of clients on every load

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@slack/client": "^3.6.0",
     "@telefonica/object-storage": "^2.2.0",
-    "alfalfa": "^2.1.0",
+    "alfalfa": "^2.2.0",
     "bingspeech-api-client": "^2.0.0",
     "botbuilder": "3.4.4",
     "express": "^4.14.0",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -55,14 +55,14 @@ export class Bot extends BotBuilder.UniversalBot {
         logger.debug('Bot supported languages', supportedLanguages);
 
         let middlewares = [
-            Audio,
+            Audio(),
             DirectLinePrompts,
             Logger,
             Normalizer,
             LanguageDetector(supportedLanguages),
             Admin,
-            EventHub,
-            Slack
+            EventHub(),
+            Slack()
         ];
         this.use(...middlewares);
 

--- a/src/middlewares/audio.spec.ts
+++ b/src/middlewares/audio.spec.ts
@@ -28,7 +28,7 @@ describe('Audio Middleware', () => {
             .reply(200, new Buffer('fake-audio-binary-contents'));
 
         let session = fakeBotSession();
-        let middleware: BotBuilder.ISessionMiddleware = audio.default.botbuilder as BotBuilder.ISessionMiddleware;
+        let middleware: BotBuilder.ISessionMiddleware = audio.default().botbuilder as BotBuilder.ISessionMiddleware;
 
         middleware(session, () => {
             expect(session.message.text).to.eq('This is a text');
@@ -45,7 +45,7 @@ describe('Audio Middleware', () => {
             .reply(200);
 
         let session = fakeBotSession();
-        let middleware: BotBuilder.ISessionMiddleware = audio.default.botbuilder as BotBuilder.ISessionMiddleware;
+        let middleware: BotBuilder.ISessionMiddleware = audio.default().botbuilder as BotBuilder.ISessionMiddleware;
 
         middleware(session, () => {
             expect(session.message.text).to.eq(''); // not replaced

--- a/src/middlewares/eventhub.ts
+++ b/src/middlewares/eventhub.ts
@@ -23,14 +23,22 @@ import * as crypto from 'crypto';
 /**
  * Sends the incoming message received by the bot to Azure Event Hub
  */
-export default {
+export default function factory(): BotBuilder.IMiddlewareMap {
+  if (!process.env.EVENTHUB_NAMESPACE) {
+    logger.warn('Eventhub Middleware is disabled. EVENTHUB_NAMESPACE env var needed');
+    return {
+      // To avoid botbuilder console.warn trace!! WTF
+      botbuilder: (session: BotBuilder.Session, next: Function) => next()
+    };
+  }
+
+  return {
     botbuilder: (session: BotBuilder.Session, next: Function) => {
-        if (process.env.EVENTHUB_NAMESPACE) {
-           sendEventHub(session.message); // best-effort, no callback
-        }
-        next();
+      sendEventHub(session.message); // best-effort, no callback
+      next();
     }
-} as BotBuilder.IMiddlewareMap;
+  } as BotBuilder.IMiddlewareMap;
+}
 
 function sendEventHub(payload: any) {
     // Event Hubs parameters

--- a/src/middlewares/language-detector.ts
+++ b/src/middlewares/language-detector.ts
@@ -23,7 +23,7 @@ export default function factory(supportedLanguages: string[]): BotBuilder.IMiddl
         botbuilder: (session: BotBuilder.Session, next: Function) => {
             resolveLocale(session, supportedLanguages)
                 .then((locale) => setSessionLocale(session, locale))
-                .then(() => next())
+                .then((locale) => next())
                 .catch((err) => next(err));
         }
     } as BotBuilder.IMiddlewareMap;
@@ -60,7 +60,7 @@ function detectClientLocale(message: BotBuilder.IMessage): string {
     return null;
 }
 
-function setSessionLocale(session: BotBuilder.Session, locale: string): Promise<void> {
+function setSessionLocale(session: BotBuilder.Session, locale: string): Promise<string> {
     return new Promise((resolve, reject) => {
         session.preferredLocale(locale, (err) => {
             if (err) {
@@ -71,8 +71,12 @@ function setSessionLocale(session: BotBuilder.Session, locale: string): Promise<
             // Save the locale as part of userData because a fallback value might be needed in future messages
             session.userData.preferredLocale = locale;
 
-            logger.info({preferredLocale: session.preferredLocale(), textLocale: session.message.textLocale}, 'Language detector');
-            return resolve();
+            logger.info({
+              preferredLocale: session.preferredLocale(),
+              textLocale: session.message.textLocale
+            }, 'Language detector');
+
+            resolve(locale);
         });
     });
 }


### PR DESCRIPTION
Audio middleware instantiated some clients when the file was required.
This causes that every plugin requiring the core, add a trace and had its own instance of that clients.

Setting the initialization in a factory function solves it.

Also, the same pattern has been applied to other middlewares, adding a warn trace when their required config parameters are missing, returning a `noop` middleware instead of checking the required configuration in each execution

Also, `alfalfa` as been updated to export the `HTTPAgentRunner`

Edit: Also fixes the error raised when no`S3_ENDPOINT` was defined that prevented the bot to startup


