### PR TITLE
[[FEAT]] Response time tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,14 @@
     "bingspeech-api-client": "^2.0.0",
     "botbuilder": "3.4.4",
     "express": "^4.14.0",
+    "express-domaining": "^2.0.1",
+    "express-tracking": "^1.0.1",
     "logops": "^1.0.6",
     "request": "^2.75.0",
     "streamifier": "^0.1.1",
-    "therror": "^2.1.0"
+    "therror": "^2.1.0",
+    "therror-connect": "^1.0.2",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "@types/chai": "^3.4.33",
@@ -59,6 +63,7 @@
     "@types/request": "0.0.31",
     "@types/sinon": "^1.16.30",
     "@types/sinon-chai": "^2.7.27",
+    "@types/uuid": "^2.0.29",
     "chai": "^3.5.0",
     "mocha": "^3.0.2",
     "nock": "^8.0.0",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -18,7 +18,17 @@
 import * as BotBuilder from 'botbuilder';
 import * as logger from 'logops';
 
-import { LanguageDetector, Admin, Logger, Normalizer, Audio, Slack, DirectLinePrompts, EventHub } from './middlewares';
+import {  LanguageDetector,
+          Admin,
+          Logger,
+          Normalizer,
+          Audio,
+          Slack,
+          DirectLinePrompts,
+          EventHub,
+          ResponseTime
+      } from './middlewares';
+
 import { PluginLoader } from './loader';
 
 export interface BotSettings extends BotBuilder.IUniversalBotSettings {
@@ -62,7 +72,8 @@ export class Bot extends BotBuilder.UniversalBot {
             LanguageDetector(supportedLanguages),
             Admin,
             EventHub(),
-            Slack()
+            Slack(),
+            ResponseTime()
         ];
         this.use(...middlewares);
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,23 +15,21 @@
 * limitations under the License.
 */
 
-export * from './bot';
-export * from './runner'
-export * from './logger';
+import * as logger from 'logops';
+import Therror from 'therror';
 
-import * as BotBuilder from 'botbuilder';
-export { BotBuilder };
+export { logger };
 
-import * as BotBuilderExt from './botbuilder-ext';
-export { BotBuilderExt };
+// But while developing, it's very boring to see them always, so we omit them
+logger.formatters.dev.omit = ['trans', 'op', 'corr'];
 
-declare module 'botbuilder' {
-    // XXX: Remove this augmentation when Microsoft fixes the interface
-    interface IRecognizeContext {
-        locale: string;
-    }
-    // XXX: Remove this augmentation when Microsoft fixes the interface
-    interface IPromptResult<T> extends IDialogResult<T> {
-        score: number;
-    }
-}
+// Set the logger for Errors to be out one
+Therror.Loggable.logger = logger;
+
+// Print in the traces out tracking info
+// @see console.runner.ts#DomainedConsoleConnector
+// @see server.runner.ts 
+// @see https://github.com/Telefonica/node-express-tracking
+logger.setContextGetter(() => {
+    return process.domain && (<any>process.domain).tracking;
+});

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -23,3 +23,4 @@ export { default as Audio } from './audio';
 export { default as Slack } from './slack';
 export { default as DirectLinePrompts } from './directline-prompts';
 export { default as EventHub } from './eventhub';
+export { default as ResponseTime } from './response-time';

--- a/src/middlewares/response-time.ts
+++ b/src/middlewares/response-time.ts
@@ -1,0 +1,74 @@
+/**
+* @license
+* Copyright 2016 Telefónica I+D
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import * as BotBuilder from 'botbuilder';
+import * as logger from 'logops';
+import * as http from 'http';
+
+export default function factory(): BotBuilder.IMiddlewareMap {
+  return {
+    /**
+     * Prints a trace when the bot replies to track the accumulated time 
+     * it last to reply to the user. 
+     * 
+     * You can use that as a metric
+     * 
+     * ```js
+     * { 
+     *   bot_response_time: { 
+     *     time: 890 # milliseconds elapsed from the initial user request,
+     *     firstReply: true # true when is the first reply of a set of replies      
+     *   }
+     *   msg: 'Bot response time',
+     *   lvl: 'INFO'
+     * }
+     */
+    send: function onSend(event: BotBuilder.IEvent, next: Function) {
+      let domain = <any>(process.domain);
+      if (!domain) {
+        return next();
+      }
+      let start = domain.start;
+      let hasReplied = domain.hasReplied;
+
+      let now = Date.now();
+
+      let trace = {
+        time: now - (start || now),
+        firstReply: false
+      };
+
+      if (!hasReplied) {
+        trace.firstReply = domain.hasReplied = true;
+      }
+
+      logger.info({ bot_response_time : trace }, 'Bot response time' );
+      next();
+    }
+  } as BotBuilder.IMiddlewareMap;
+}
+
+/**
+ * Adds the current time to the domain
+ */
+export function addStartTime() {
+  if (process.domain) {
+    Object.assign(process.domain, {
+      start: Date.now()
+    });
+  }
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -15,6 +15,8 @@
 * limitations under the License.
 */
 
-export * from 'alfalfa';
+// alfalfa also exports its own logger as logger. It will collide with our own (@see logger.ts)
+// so drop it from the exported members
+export { Errors as RunnerErrors, Runner, ServerRunner, MongoRunner, HTTPAgentRunner, Startup } from 'alfalfa';
 export { BotConsoleRunner } from './console.runner';
 export { BotServerRunner } from './server.runner';

--- a/src/server.runner.ts
+++ b/src/server.runner.ts
@@ -19,8 +19,12 @@ import * as express from 'express';
 import * as logger from 'logops';
 import * as BotBuilder from 'botbuilder';
 import * as http from 'http';
-import enableTerminate = require('server-terminate');
+import * as enableTerminate from 'server-terminate';
+const expressDomain = require('express-domaining');
+const expressTracking = require('express-tracking');
+const errorHandler = require('therror-connect');
 
+import { addStartTime } from './middlewares/response-time';
 import { Runner, ServerRunner } from './runner';
 
 /**
@@ -75,10 +79,43 @@ export class BotServerRunner extends ServerRunner {
 
         this.app = app;
         this.app.disable('x-powered-by');
-        this.app.post('/api/messages', this.connector.listen());
+        this.app.post('/api/messages', [
+          expressDomain(), // Add domain support
+          expressTracking(), // Add traking information
+          addTimeMW, // Add request start time 
+          this.connector.listen()
+        ]);
         this.app.get('/status', statusMW);
         this.app.use('*', defaultMW);
+        this.app.use([
+          domainErrorMW, // manage domain errors
+          errorHandler() // And add useful logging errors - responses
+        ]);
     }
+}
+
+/**
+ * Express middleware that adds the current time to the domain, 
+ * in order to get from the bot middleware "response-time" later 
+ * @see middlewares/request-time.ts
+ */
+export function addTimeMW(req: http.ClientRequest, res: http.ClientResponse, next: Function): void {
+  addStartTime();
+  next();
+}
+/**
+ * Express error handler that prints a domain thrown error as a fatal trace
+ * expressDomainig forwards the domain error to express, so we capture them here 
+ * and add a fatal trace (as a domain error is an unexpected one)
+ */
+function domainErrorMW(err: any | Error, req: express.Request, res: express.Response, next: Function) {
+  // domain thrown errors. The process will exit cleanly thaks to alfalfa when 
+  // the request ends and the client got it response, but we first log the fatal trace 
+  if (err.domainThrown) {
+    // To print AFTER the request error log
+    process.nextTick(() => logger.fatal(err));
+  }
+  next(err);
 }
 
 function statusMW(req: express.Request, res: express.Response) {


### PR DESCRIPTION
Prints a trace when the bot replies to track the accumulated time it last to reply to the user.
You can use that as a metric

```js
{
  bot_response_time: {
    time: 890 # milliseconds elapsed from the initial user request,
    firstReply: true # true when is the first reply of a set of replies
  }
  msg: 'Bot response time',
  lvl: 'INFO'
}
```

Now the server and console runners go inside a [domain](https://nodejs.org/api/domain.html),
so we can correlate requests.

The logger has been configured to print the correlation information, but only in json mode

In order to allow all the bot-core peers to use that functionality, without needing to configure
its own loggers, the core one has been exported

All the plugins and bots can safely replace
```js
import * as logger from `logops`;
```

with

```js
import { logger } from `@telefonica/bot-core`;
```
otherwise, the correlation info will not be shown in their own traces unless explicitelly configured