### PR TITLE
fix(BotBuilderExt): Fix 'reading property of undefined object' error

### DIFF
--- a/src/botbuilder-ext/Prompts.ts
+++ b/src/botbuilder-ext/Prompts.ts
@@ -185,7 +185,7 @@ export class Prompts extends BotBuilder.Prompts {
 
         args.promptType = BotBuilder.PromptType.confirm;
         args.prompt = prompt;
-        if (options.yesNoChoices) {
+        if (options && options.yesNoChoices) {
             let yesNoChoices = BotBuilder.EntityRecognizer.expandChoices(options.yesNoChoices);
             if (yesNoChoices.length !== 2) {
                 console.error('yesNoChoices must have length 2');


### PR DESCRIPTION
With this solution we are not modifying the final behavior. With the && operator we make sure that yesNoChoices property is not read when 'options' argument is not defined.

- Fixes #20 