### PR TITLE
[[FEAT]] Upgraded botbuilder to latest version (3.7.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telefonica/bot-core",
-  "version": "1.35.1",
+  "version": "2.0.0",
   "description": "Bot Core module to develop bots based on Microsoft Bot Framework",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
     "alfalfa": "^2.2.0",
     "azure-event-hubs": "0.0.6",
     "bingspeech-api-client": "^2.2.0",
-    "botbuilder": "3.4.4",
+    "botbuilder": "3.7.0",
     "express": "^4.14.0",
     "express-domaining": "^2.0.1",
     "express-ping": "^1.4.0",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -47,7 +47,9 @@ export class Bot extends BotBuilder.UniversalBot {
         settings.defaultDialogArgs = settings.defaultDialogArgs || {};
         settings.defaultDialogArgs.promptsCancelIntentsBlacklist = settings.promptsCancelIntentsBlacklist;
 
-        super(null, settings);
+        // UniversalBot has three constructors, but the interface definition is using the wrong one (not the most generic),
+        // so this "casting" is required
+        super(null, <any>settings);
 
         this.loader = new PluginLoader(settings.plugins);
 
@@ -107,7 +109,7 @@ export class Bot extends BotBuilder.UniversalBot {
         intentDialog.onDefault((session: BotBuilder.Session, result: any) => {
             logger.debug('Find library for intent [%s]', result.intent);
 
-            let dialogName = this.findDialog(result.intent, libraries);
+            let dialogName = this.findMyDialog(result.intent, libraries);
 
             if (dialogName) {
                 logger.debug({ result }, 'Starting library dialog [%s]', dialogName);
@@ -122,7 +124,8 @@ export class Bot extends BotBuilder.UniversalBot {
         return intentDialog;
     }
 
-    private findDialog(intent: string, libraries: BotBuilder.Library[]): string {
+    // The name of this method cannot be "findDialog", as it is a non-private method in UniversalBot
+    private findMyDialog(intent: string, libraries: BotBuilder.Library[]): string {
         let dialogName: string;
 
         libraries.some(library => {

--- a/src/botbuilder-ext/Prompts.ts
+++ b/src/botbuilder-ext/Prompts.ts
@@ -77,11 +77,19 @@ export class Prompts extends BotBuilder.Prompts {
         logger.debug('The reply has not been recognized. Looking for an intent to change the dialog on the fly...');
 
         let dlg = <BotBuilder.IntentDialog>session.library.dialog('/');
-        let context: BotBuilder.IRecognizeContext = {
+        let context: BotBuilder.IRecognizeDialogContext = {
             message: session.message,
             locale: session.preferredLocale(),
             dialogData: session.dialogData,
-            activeDialog: true
+            activeDialog: true,
+            userData: session.userData,
+            conversationData: session.conversationData,
+            privateConversationData: session.privateConversationData,
+            localizer: session.localizer,
+            preferredLocale: session.preferredLocale,
+            gettext: session.gettext,
+            ngettext: session.ngettext,
+            dialogStack: session.dialogStack
         };
         dlg.recognize(context, (err: Error, recognitionResult: BotBuilder.IIntentRecognizerResult) => {
             if (err) {


### PR DESCRIPTION
Adapted bot-core to use botbuilder 3.7.0

When using new bot-core 2.0.0, the bot must change the i18n keys to include the library, for example from `"bill.unusual.message"` to `"bill:bill.unusual.message"`