### PR TITLE
[[FIX]] Fixed i18n in key from a library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telefonica/bot-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Bot Core module to develop bots based on Microsoft Bot Framework",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/botbuilder-ext/Prompts.ts
+++ b/src/botbuilder-ext/Prompts.ts
@@ -203,8 +203,8 @@ export class Prompts extends BotBuilder.Prompts {
             // - In the case that the prompt is not a BotBuilder.IMessage, those will be the labels for the buttons.
             // - Those values are automatically recognized by the EntityRecognizer as valid yes/no responses.
             args.enumValues = [
-                session.localizer.gettext(locale, yesNoChoices[0]),
-                session.localizer.gettext(locale, yesNoChoices[1])
+                session.gettext(yesNoChoices[0]),
+                session.gettext(yesNoChoices[1])
             ];
         } else {
             args.enumValues = [


### PR DESCRIPTION
From botbuilder [3.5 and later](https://github.com/Microsoft/BotBuilder/blob/botbuilder%403.7.0/Node/core/src/Session.ts#L192), `session.gettext` has changed, sending the current library to [vgettext](https://github.com/Microsoft/BotBuilder/blob/botbuilder%403.7.0/Node/core/src/Session.ts#L654) and then to `session.localizer.gettext`.

Old `session.localizer.gettext` called with 2 arguments, caused to recover the key from system library, instead of dialog library (that is now passed by new [session.gettext](https://github.com/Microsoft/BotBuilder/blob/botbuilder%403.7.0/Node/core/src/Session.ts#L193)).