### PR TITLE
[[FEAT]] define in botsettings the recognizers to be used defined as general IIntentRecognizers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telefonica/bot-core",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Bot Core module to develop bots based on Microsoft Bot Framework",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -33,12 +33,10 @@ import { PluginLoader } from './loader';
 
 export interface BotSettings extends BotBuilder.IUniversalBotSettings {
     /** Set of IIntentRecognizer objects already initializated externally */
-    intentRecognizers?: BotBuilder.IIntentRecognizer[];
-    recognizeOrder?: BotBuilder.RecognizeOrder;    
+    intentRecognizers: BotBuilder.IIntentRecognizer[];
+    recognizeOrder: BotBuilder.RecognizeOrder;    
     /** Set of supported languages of the intentRecognizers set*/
-    supportedLanguages?: string[];
-    
-    modelMapSet: BotBuilder.ILuisModelMap[];
+    supportedLanguages: string[];
     plugins: string[];
     /** Blacklisted intents that should never cancel a BotBuilderExt.Prompts dialog */
     promptsCancelIntentsBlacklist?: string[];
@@ -96,20 +94,6 @@ export class Bot extends BotBuilder.UniversalBot {
 
     private createIntentDialog(): BotBuilder.IntentDialog {
         let recognizers = this.initializeLanguageRecognizers();
-
-        // For backwards compatibility
-        let qnaEnabled = process.env.QNA_KNOWLEDGEBASE_ID && process.env.QNA_SUBSCRIPTION_KEY;
-        if (qnaEnabled) {
-            const cognitiveservices = require('botbuilder-cognitiveservices');
-
-            let qnaRecognizer = new cognitiveservices.QnAMakerRecognizer({
-                knowledgeBaseId: process.env.QNA_KNOWLEDGEBASE_ID,
-                subscriptionKey: process.env.QNA_SUBSCRIPTION_KEY
-            });
-
-            logger.info('Add QnA recognizer', process.env.QNA_KNOWLEDGEBASE_ID);
-            recognizers = [qnaRecognizer, ...recognizers]; // QnA recognizer must go first
-        }
 
         let recognizerOrder = this.get('recognizeOrder') as BotBuilder.RecognizeOrder;
         if (typeof recognizerOrder === 'undefined' || recognizerOrder === null) {
@@ -173,67 +157,28 @@ export class Bot extends BotBuilder.UniversalBot {
     }
 
     private initializeLanguageRecognizers(): BotBuilder.IIntentRecognizer[] {
-
-        // For backwards compatibility of modelMapSet
-        let modelMapSet = this.get('modelMapSet') as BotBuilder.ILuisModelMap[] || [];
-        if (!modelMapSet || !modelMapSet.length) {
-            logger.info('No LUIS models defined in modelMapSet');
-        }
-        else {
-            logger.info('Load LUIS models defined in modelMapSet', modelMapSet);
-        }
-
-        let recognizersByMapSet = modelMapSet.map((modelMap: BotBuilder.ILuisModelMap) => {
-            return new BotBuilder.LuisRecognizer(modelMap);
-        });
-
-        // In intentRecognizers (if exist) will come a set of IIntentRecognizer objects 
+        // In intentRecognizers will come a set of IIntentRecognizer objects 
         // already initializated:
         // QnAMakerRecognizer, LuisRecognizer, and more...
         //
-        let intentRecognizers = this.get('intentRecognizers') as BotBuilder.IIntentRecognizer[] || [];
+        let intentRecognizers = this.get('intentRecognizers') as BotBuilder.IIntentRecognizer[];
         if (!intentRecognizers || !intentRecognizers.length) {
             logger.error('No Recognizer models defined in intentRecognizers');
-        }
-        else {
-            logger.info('Load Recognizer models defined in intentRecognizers', intentRecognizers);
+            return [];
         }
 
-        let recognizersFinallyDefined = [...recognizersByMapSet, ...intentRecognizers];
-
-        return recognizersFinallyDefined;
+        return intentRecognizers;
     }
 
     private supportedLanguages(): string[] {
-
-        // For backwards compatibility of modelMapSet
-        let languagesByMapSet: string[] = [];
-        let modelMapSet = this.get('modelMapSet') as BotBuilder.ILuisModelMap[] || [];
-        if (!modelMapSet || !modelMapSet.length) {
-            logger.info('No Supported Languages defined in modelMapSet');
-        }
-        else {
-            languagesByMapSet = modelMapSet
-                .map((modelMap) => Object.keys(modelMap))
-                .reduce((a, b) => a.concat(b))
-                .filter((v, i, a) => a.indexOf(v) === i); // unique
-        }
-
-        // In supportedLanguages (if exist) will come a set off 
-        let languagesBySupportedLanguages: string[] = [];
-        let supportedLanguages = this.get('supportedLanguages') as string[] || [];
+        let supportedLanguages = this.get('supportedLanguages') as string[];
         if (!supportedLanguages || !supportedLanguages.length) {
             logger.info('No Supported Languages defined in supportedLanguages');
-        }
-        else {
-            languagesBySupportedLanguages = supportedLanguages
-                .filter((v, i, a) => a.indexOf(v) === i); // unique
+            return [];
         }
 
-        let languagesFinallyDefined = [...languagesByMapSet, ...languagesBySupportedLanguages]
-            .filter((v, i, a) => a.indexOf(v) === i); // unique
-
-        return languagesFinallyDefined;
+        let languages = supportedLanguages.filter((v, i, a) => a.indexOf(v) === i); // unique
+        return languages;
     }
 }
 


### PR DESCRIPTION
 The idea is define externally the recognizers QnAMakerRecognizer, LuisRecognizer, and others
 and put they in the BotSettings as IIntentRecognizers, and also to define externally  the recognizerOrder and the supported languages.  